### PR TITLE
fix bug where resetting the form causes causes an error due to null value being sent

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -44,7 +44,7 @@ const getValidator = (name, value, options) => {
 export function getParamValidator(name: string) {
   return (options?: any) => {
     return (c: AbstractControl) => {
-      return getValidator(name, c.value, options);
+      return getValidator(name, c.value != null ? c.value : '', options);
     };
   };
 }


### PR DESCRIPTION
Call .reset() on the FormGroup to see the error